### PR TITLE
Add Share Snippet Feature

### DIFF
--- a/app/api/share/[token]/route.ts
+++ b/app/api/share/[token]/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { snippets } from '@/lib/db/schema';
+import { eq, and } from 'drizzle-orm';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ token: string }> }
+) {
+  try {
+    const { token } = await params;
+
+    const snippet = await db.query.snippets.findFirst({
+      where: and(eq(snippets.shareToken, token), eq(snippets.isShared, true)),
+      with: {
+        tags: {
+          with: {
+            tag: true,
+          },
+        },
+      },
+    });
+
+    if (!snippet) {
+      return NextResponse.json(
+        { error: 'Snippet not found' },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({
+      snippet: {
+        ...snippet,
+        created_at: snippet.createdAt instanceof Date ? snippet.createdAt.toISOString() : snippet.createdAt,
+        updated_at: snippet.updatedAt instanceof Date ? snippet.updatedAt.toISOString() : snippet.updatedAt,
+        tags: snippet.tags.map((st: { tag: { id: string; name: string } }) => ({
+          id: st.tag.id,
+          name: st.tag.name,
+        })),
+      },
+    });
+  } catch (error) {
+    console.error('[v0] Get shared snippet error:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/snippets/[id]/route.ts
+++ b/app/api/snippets/[id]/route.ts
@@ -11,6 +11,7 @@ const updateSnippetSchema = z.object({
   code: z.string().min(1).optional(),
   language: z.string().min(1).optional(),
   tags: z.array(z.string()).optional(),
+  isShared: z.boolean().optional(),
 });
 
 async function getUserIdFromSession(): Promise<string | null> {
@@ -108,6 +109,12 @@ export async function PUT(
     if (updates.description !== undefined) updateData.description = updates.description;
     if (updates.code !== undefined) updateData.code = updates.code;
     if (updates.language !== undefined) updateData.language = updates.language;
+    if (updates.isShared !== undefined) {
+      updateData.isShared = updates.isShared;
+      if (updates.isShared && !snippet.shareToken) {
+        updateData.shareToken = crypto.randomUUID();
+      }
+    }
     updateData.updatedAt = new Date();
 
     await db.update(snippets).set(updateData).where(eq(snippets.id, id));

--- a/app/share/[token]/page.tsx
+++ b/app/share/[token]/page.tsx
@@ -1,0 +1,176 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { CodeDisplay } from '@/components/code-display';
+import { FileCode2, CalendarClock, Tag, Copy, Check } from 'lucide-react';
+import { useToast } from '@/hooks/use-toast';
+import { useParams } from 'next/navigation';
+
+type Snippet = {
+  id: string;
+  title: string;
+  description?: string;
+  language: string;
+  tags?: Array<{ id: string; name: string }>;
+  code: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export default function SharedSnippetPage() {
+  const params = useParams();
+  const token = params.token as string;
+  const [snippet, setSnippet] = useState<Snippet | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const { toast } = useToast();
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (token) {
+      fetchSnippet(token);
+    }
+  }, [token]);
+
+  const fetchSnippet = async (token: string) => {
+    try {
+      const response = await fetch(`/api/share/${token}`);
+      if (!response.ok) {
+        setError('Snippet not found or private');
+        return;
+      }
+      const data = await response.json();
+      setSnippet(data.snippet);
+    } catch (err) {
+      setError('Failed to load snippet');
+      console.error('[v0] Fetch shared snippet error:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleCopyLink = () => {
+    navigator.clipboard.writeText(window.location.href);
+    setCopied(true);
+    toast({
+      title: 'Link copied',
+      description: 'The link has been copied to your clipboard.',
+    });
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center text-muted-foreground">
+        Loading shared snippet...
+      </div>
+    );
+  }
+
+  if (!snippet) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center p-4">
+        <h1 className="text-2xl font-bold mb-2">Snippet Not Found</h1>
+        <p className="text-muted-foreground">{error || 'The snippet you are looking for does not exist or is private.'}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen p-3 text-foreground sm:p-4 bg-background">
+      <div className="window-shell mx-auto flex min-h-[calc(100vh-1.5rem)] w-full max-w-[1700px] flex-col overflow-hidden rounded-xl sm:min-h-[calc(100vh-2rem)] border border-border">
+        <header className="window-titlebar h-12 bg-card/50 border-b border-border">
+          <div className="window-controls">
+            <span />
+            <span />
+            <span />
+          </div>
+
+          <div className="flex min-w-0 items-center gap-2">
+            <FileCode2 className="h-4 w-4 shrink-0 text-primary" />
+            <span className="truncate text-sm text-muted-foreground">Shared Snippet / {snippet.title}</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              onClick={handleCopyLink}
+              variant="outline"
+              className="h-8 border-border/80 bg-card/75 px-3 hover:bg-secondary"
+            >
+              {copied ? <Check className="mr-1.5 h-4 w-4" /> : <Copy className="mr-1.5 h-4 w-4" />}
+              {copied ? 'Copied' : 'Copy Link'}
+            </Button>
+          </div>
+        </header>
+
+        <div className="grid min-h-0 flex-1 lg:grid-cols-[280px_1fr]">
+          <aside className="explorer-pane p-3 sm:p-4 border-r border-border bg-card/30">
+            <Card className="ide-panel h-fit p-4">
+              <h2 className="mb-3 text-xs uppercase tracking-wide text-muted-foreground">File Info</h2>
+              <div className="space-y-4">
+                <div>
+                  <p className="mb-1 text-xs text-muted-foreground">Name</p>
+                  <p className="break-words font-medium">{snippet.title}</p>
+                </div>
+                <div>
+                  <p className="mb-1 text-xs text-muted-foreground">Language</p>
+                  <span className="rounded-md border border-primary/35 bg-primary/15 px-2 py-1 text-xs text-primary">
+                    {snippet.language}
+                  </span>
+                </div>
+                <div>
+                  <p className="mb-1 flex items-center gap-1 text-xs text-muted-foreground">
+                    <Tag className="h-3.5 w-3.5" />
+                    Tags
+                  </p>
+                  <div className="flex flex-wrap gap-1.5">
+                    {snippet.tags && snippet.tags.length > 0 ? (
+                      snippet.tags.map((tag) => (
+                        <Badge key={tag.id} variant="secondary" className="border-border/70 bg-secondary/85 text-foreground">
+                          {tag.name}
+                        </Badge>
+                      ))
+                    ) : (
+                      <span className="text-sm text-muted-foreground">No tags</span>
+                    )}
+                  </div>
+                </div>
+                <div>
+                  <p className="mb-1 flex items-center gap-1 text-xs text-muted-foreground">
+                    <CalendarClock className="h-3.5 w-3.5" />
+                    Last updated
+                  </p>
+                  <p className="text-sm text-muted-foreground">
+                    {new Date(snippet.updated_at).toLocaleDateString('en-US', {
+                      year: 'numeric',
+                      month: 'short',
+                      day: 'numeric',
+                      hour: '2-digit',
+                      minute: '2-digit',
+                    })}
+                  </p>
+                </div>
+              </div>
+            </Card>
+          </aside>
+
+          <section className="editor-pane min-h-0 overflow-y-auto p-4 md:p-6 bg-background">
+            <Card className="ide-panel overflow-hidden">
+              <div className="border-b border-border/75 bg-card/85 px-4 py-3">
+                <h2 className="font-medium">{snippet.title}.{snippet.language}</h2>
+                {snippet.description && (
+                  <p className="mt-1 text-sm text-muted-foreground">{snippet.description}</p>
+                )}
+              </div>
+              <div className="p-4">
+                <CodeDisplay code={snippet.code} language={snippet.language} />
+              </div>
+            </Card>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/snippet-detail.tsx
+++ b/components/snippet-detail.tsx
@@ -7,7 +7,19 @@ import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { CodeDisplay } from './code-display';
 import { SnippetEditor } from './snippet-editor';
-import { ArrowLeft, Edit, Trash2, FileCode2, CalendarClock, Tag } from 'lucide-react';
+import { ArrowLeft, Edit, Trash2, FileCode2, CalendarClock, Tag, Share, Copy, Check } from 'lucide-react';
+import { useToast } from '@/hooks/use-toast';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import { Switch } from "@/components/ui/switch"
+import { Label } from "@/components/ui/label"
+import { Input } from "@/components/ui/input"
 
 type Snippet = {
   id: string;
@@ -18,6 +30,8 @@ type Snippet = {
   code: string;
   created_at: string;
   updated_at: string;
+  isShared?: boolean;
+  shareToken?: string;
 };
 
 type SnippetDetailProps = {
@@ -30,6 +44,8 @@ export function SnippetDetail({ snippetId }: SnippetDetailProps) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
   const [showEditor, setShowEditor] = useState(false);
+  const { toast } = useToast();
+  const [copied, setCopied] = useState(false);
 
   useEffect(() => {
     fetchSnippet();
@@ -66,6 +82,54 @@ export function SnippetDetail({ snippetId }: SnippetDetailProps) {
       setError('Failed to delete snippet');
     }
   };
+
+  const handleShareToggle = async (enabled: boolean) => {
+    try {
+      const response = await fetch(`/api/snippets/${snippetId}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ isShared: enabled }),
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to update share settings');
+      }
+
+      const data = await response.json();
+      setSnippet(data.snippet);
+
+      toast({
+        title: enabled ? 'Snippet shared' : 'Snippet private',
+        description: enabled ? 'Anyone with the link can view this snippet.' : 'This snippet is now private.',
+      });
+    } catch (err) {
+      toast({
+        title: 'Error',
+        description: 'Failed to update share settings',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  const getShareUrl = () => {
+    if (!snippet?.shareToken) return '';
+    return `${window.location.origin}/share/${snippet.shareToken}`;
+  };
+
+  const copyToClipboard = () => {
+    const url = getShareUrl();
+    if (!url) return;
+
+    navigator.clipboard.writeText(url);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+    toast({
+        title: "Link copied",
+        description: "Share link copied to clipboard",
+    })
+  }
 
   if (loading) {
     return (
@@ -106,6 +170,47 @@ export function SnippetDetail({ snippetId }: SnippetDetailProps) {
             <span className="truncate text-sm text-muted-foreground">Workspace / snippets / {snippet.title}</span>
           </div>
           <div className="flex items-center gap-2">
+            <Dialog>
+                <DialogTrigger asChild>
+                    <Button
+                    variant="outline"
+                    className="h-8 border-border/80 bg-card/75 px-3 hover:bg-secondary"
+                    >
+                    <Share className="mr-1.5 h-4 w-4" />
+                    Share
+                    </Button>
+                </DialogTrigger>
+                <DialogContent>
+                    <DialogHeader>
+                    <DialogTitle>Share Snippet</DialogTitle>
+                    <DialogDescription>
+                        Make your snippet public to share it with others.
+                    </DialogDescription>
+                    </DialogHeader>
+                    <div className="flex items-center space-x-2 py-4">
+                    <Switch
+                        id="share-mode"
+                        checked={snippet.isShared}
+                        onCheckedChange={handleShareToggle}
+                    />
+                    <Label htmlFor="share-mode">Public access</Label>
+                    </div>
+
+                    {snippet.isShared && (
+                    <div className="flex items-center space-x-2 mt-2">
+                        <Input
+                        readOnly
+                        value={getShareUrl()}
+                        className="flex-1"
+                        />
+                        <Button size="icon" variant="outline" onClick={copyToClipboard}>
+                            {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+                        </Button>
+                    </div>
+                    )}
+                </DialogContent>
+            </Dialog>
+
             <Button
               onClick={() => setShowEditor(true)}
               variant="outline"

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -171,6 +171,8 @@ export const snippets = pgTable(
     description: text('description'),
     code: text('code').notNull(),
     language: text('language').notNull().default('javascript'),
+    isShared: boolean('is_shared').notNull().default(false),
+    shareToken: text('share_token').unique(),
     createdAt: timestamp('created_at').defaultNow().notNull(),
     updatedAt: timestamp('updated_at').defaultNow().notNull(),
   },


### PR DESCRIPTION
Added ability to share snippets publicly via a unique link.
This includes:
- Database schema changes (is_shared, share_token columns).
- Backend API updates for snippet sharing and public access.
- Frontend component updates for share button and public view page.

---
*PR created automatically by Jules for task [13537298874575552552](https://jules.google.com/task/13537298874575552552) started by @dhanushreddy291*